### PR TITLE
Generaliseer codec-tag renaming in outputbestandsnamen

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Configuration is stored in `/config/shrinkray.yaml`. Most settings are available
 | `media_path` | `/media` | Root directory to browse |
 | `temp_path` | *(empty)* | Fast storage for temp files (SSD recommended) |
 | `original_handling` | `replace` | `replace` = delete original, `keep` = rename to `.old` |
+| `rename_h264_to_h265` | `false` | Update codec tag in output filenames to match output codec |
 | `workers` | `1` | Concurrent transcode jobs (1–6) |
 | `quality_hevc` | `0` | CRF override for HEVC (0 = default, range: 15–40) |
 | `quality_av1` | `0` | CRF override for AV1 (0 = default, range: 20–50) |
@@ -172,6 +173,7 @@ Configuration is stored in `/config/shrinkray.yaml`. Most settings are available
 media_path: /media
 temp_path: /tmp/shrinkray
 original_handling: replace
+rename_h264_to_h265: false
 workers: 2
 quality_hevc: 24
 schedule_enabled: true

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -275,22 +275,23 @@ func (h *Handler) GetConfig(w http.ResponseWriter, r *http.Request) {
 
 	// Return a sanitized config (no sensitive paths exposed)
 	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"version":               shrinkray.Version,
-		"media_path":            h.cfg.MediaPath,
-		"original_handling":     h.cfg.OriginalHandling,
-		"workers":               h.cfg.Workers,
-		"has_temp_path":         h.cfg.TempPath != "",
-		"pushover_user_key":     h.cfg.PushoverUserKey,
-		"pushover_app_token":    h.cfg.PushoverAppToken,
-		"pushover_configured":   h.pushover.IsConfigured(),
-		"notify_on_complete":    h.cfg.NotifyOnComplete,
-		"quality_hevc":          h.cfg.QualityHEVC,
-		"quality_av1":           h.cfg.QualityAV1,
-		"default_quality_hevc":  defaultHEVC,
-		"default_quality_av1":   defaultAV1,
-		"schedule_enabled":      h.cfg.ScheduleEnabled,
-		"schedule_start_hour":   h.cfg.ScheduleStartHour,
-		"schedule_end_hour":     h.cfg.ScheduleEndHour,
+		"version":              shrinkray.Version,
+		"media_path":           h.cfg.MediaPath,
+		"original_handling":    h.cfg.OriginalHandling,
+		"workers":              h.cfg.Workers,
+		"has_temp_path":        h.cfg.TempPath != "",
+		"pushover_user_key":    h.cfg.PushoverUserKey,
+		"pushover_app_token":   h.cfg.PushoverAppToken,
+		"pushover_configured":  h.pushover.IsConfigured(),
+		"notify_on_complete":   h.cfg.NotifyOnComplete,
+		"quality_hevc":         h.cfg.QualityHEVC,
+		"quality_av1":          h.cfg.QualityAV1,
+		"default_quality_hevc": defaultHEVC,
+		"default_quality_av1":  defaultAV1,
+		"rename_h264_to_h265":  h.cfg.RenameH264ToH265,
+		"schedule_enabled":     h.cfg.ScheduleEnabled,
+		"schedule_start_hour":  h.cfg.ScheduleStartHour,
+		"schedule_end_hour":    h.cfg.ScheduleEndHour,
 	})
 }
 
@@ -303,6 +304,7 @@ type UpdateConfigRequest struct {
 	NotifyOnComplete  *bool   `json:"notify_on_complete,omitempty"`
 	QualityHEVC       *int    `json:"quality_hevc,omitempty"`
 	QualityAV1        *int    `json:"quality_av1,omitempty"`
+	RenameH264ToH265  *bool   `json:"rename_h264_to_h265,omitempty"`
 	ScheduleEnabled   *bool   `json:"schedule_enabled,omitempty"`
 	ScheduleStartHour *int    `json:"schedule_start_hour,omitempty"`
 	ScheduleEndHour   *int    `json:"schedule_end_hour,omitempty"`
@@ -361,6 +363,9 @@ func (h *Handler) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.cfg.QualityAV1 = *req.QualityAV1
+	}
+	if req.RenameH264ToH265 != nil {
+		h.cfg.RenameH264ToH265 = *req.RenameH264ToH265
 	}
 
 	// Handle schedule settings

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -196,6 +196,9 @@ func TestConfigEndpoint(t *testing.T) {
 	if cfg["original_handling"] != "replace" {
 		t.Errorf("expected original_handling 'replace', got %v", cfg["original_handling"])
 	}
+	if cfg["rename_h264_to_h265"] != false {
+		t.Errorf("expected rename_h264_to_h265 false, got %v", cfg["rename_h264_to_h265"])
+	}
 
 	t.Logf("Config: %v", cfg)
 }
@@ -205,8 +208,10 @@ func TestUpdateConfigEndpoint(t *testing.T) {
 
 	// Update config
 	keepVal := "keep"
+	renameVal := true
 	reqBody := UpdateConfigRequest{
 		OriginalHandling: &keepVal,
+		RenameH264ToH265: &renameVal,
 	}
 	body, _ := json.Marshal(reqBody)
 
@@ -231,6 +236,9 @@ func TestUpdateConfigEndpoint(t *testing.T) {
 
 	if cfg["original_handling"] != "keep" {
 		t.Errorf("expected original_handling 'keep', got %v", cfg["original_handling"])
+	}
+	if cfg["rename_h264_to_h265"] != true {
+		t.Errorf("expected rename_h264_to_h265 true, got %v", cfg["rename_h264_to_h265"])
 	}
 }
 
@@ -295,4 +303,3 @@ func TestJobStreamEndpoint(t *testing.T) {
 
 	t.Logf("SSE response: %s", w.Body.String()[:min(200, len(w.Body.String()))])
 }
-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,9 @@ type Config struct {
 	// QualityAV1 is the CRF value for AV1 encoding (lower = higher quality, default 35)
 	QualityAV1 int `yaml:"quality_av1"`
 
+	// RenameH264ToH265 updates codec tags in the output filename to match the target codec
+	RenameH264ToH265 bool `yaml:"rename_h264_to_h265"`
+
 	// ScheduleEnabled enables time-based scheduling for transcoding
 	ScheduleEnabled bool `yaml:"schedule_enabled"`
 
@@ -76,6 +79,7 @@ func DefaultConfig() *Config {
 		QueueFile:         "/config/queue.json",
 		QualityHEVC:       0, // 0 = use encoder-specific default
 		QualityAV1:        0, // 0 = use encoder-specific default
+		RenameH264ToH265:  false,
 		ScheduleEnabled:   false,
 		ScheduleStartHour: 22, // 10 PM
 		ScheduleEndHour:   6,  // 6 AM

--- a/internal/ffmpeg/transcode_test.go
+++ b/internal/ffmpeg/transcode_test.go
@@ -40,6 +40,24 @@ func TestBuildTempPath(t *testing.T) {
 	}
 }
 
+func TestBuildOutputPathRenameCodecTag(t *testing.T) {
+	input := "/media/Arcadia S01E02 [HDTV-1080p][AAC 2.0][h264]-S4LVE.mkv"
+	expected := "/media/Arcadia S01E02 [HDTV-1080p][AAC 2.0][h265]-S4LVE.mkv"
+	result := BuildOutputPath(input, true, CodecHEVC)
+	if result != expected {
+		t.Errorf("BuildOutputPath rename = %s, expected %s", result, expected)
+	}
+}
+
+func TestBuildOutputPathRenameCodecTagAV1(t *testing.T) {
+	input := "/media/Movie [x265].mkv"
+	expected := "/media/Movie [av1].mkv"
+	result := BuildOutputPath(input, true, CodecAV1)
+	if result != expected {
+		t.Errorf("BuildOutputPath rename av1 = %s, expected %s", result, expected)
+	}
+}
+
 func TestTranscode(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping transcode test in short mode")
@@ -142,7 +160,7 @@ func TestFinalizeTranscodeReplace(t *testing.T) {
 	}
 
 	// Finalize with replace=true
-	finalPath, err := FinalizeTranscode(originalPath, tempPath, true)
+	finalPath, err := FinalizeTranscode(originalPath, tempPath, true, false, CodecHEVC)
 	if err != nil {
 		t.Fatalf("FinalizeTranscode failed: %v", err)
 	}
@@ -192,7 +210,7 @@ func TestFinalizeTranscodeReplaceDifferentExt(t *testing.T) {
 	}
 
 	// Finalize with replace=true
-	finalPath, err := FinalizeTranscode(originalPath, tempPath, true)
+	finalPath, err := FinalizeTranscode(originalPath, tempPath, true, false, CodecHEVC)
 	if err != nil {
 		t.Fatalf("FinalizeTranscode failed: %v", err)
 	}
@@ -235,7 +253,7 @@ func TestFinalizeTranscodeKeep(t *testing.T) {
 	}
 
 	// Finalize with replace=false (keep original as .old)
-	finalPath, err := FinalizeTranscode(originalPath, tempPath, false)
+	finalPath, err := FinalizeTranscode(originalPath, tempPath, false, false, CodecHEVC)
 	if err != nil {
 		t.Fatalf("FinalizeTranscode failed: %v", err)
 	}

--- a/internal/jobs/worker.go
+++ b/internal/jobs/worker.go
@@ -419,7 +419,7 @@ func (w *Worker) processJob(job *Job) {
 
 	// Finalize the transcode (handle original file)
 	replace := w.cfg.OriginalHandling == "replace"
-	finalPath, err := ffmpeg.FinalizeTranscode(job.InputPath, tempPath, replace)
+	finalPath, err := ffmpeg.FinalizeTranscode(job.InputPath, tempPath, replace, w.cfg.RenameH264ToH265, preset.Codec)
 	if err != nil {
 		// Try to clean up
 		os.Remove(tempPath)

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1482,6 +1482,15 @@
                     </div>
                     <div class="setting-item">
                         <div class="setting-info">
+                            <div class="setting-name">Rename codec tag</div>
+                            <div class="setting-desc">Update codec tag in output filenames</div>
+                        </div>
+                        <div class="setting-control">
+                            <input type="checkbox" id="setting-rename-h264" onchange="updateSetting('rename_h264_to_h265', this.checked)">
+                        </div>
+                    </div>
+                    <div class="setting-item">
+                        <div class="setting-info">
                             <div class="setting-name">Concurrent jobs</div>
                             <div class="setting-desc">Simultaneous transcode tasks</div>
                         </div>
@@ -2296,6 +2305,7 @@
                 }
 
                 document.getElementById('setting-original-handling').value = config.original_handling || 'replace';
+                document.getElementById('setting-rename-h264').checked = config.rename_h264_to_h265 || false;
                 document.getElementById('setting-workers').value = config.workers || 1;
 
                 // Pushover settings


### PR DESCRIPTION
### Motivation

- Bestaande implementatie verving alleen `h264`→`h265`, maar gebruikers kunnen ook naar `av1` (of andere combinaties) transcoderen en de bron-tag varieert, dus de rename moet flexibeler zijn.
- De operatie moet alleen de codec-tag in de bestandsnaam bijwerken zodat outputbestandsnamen consistente codec-aanduiding hebben zonder andere delen van de naam te breken.

### Description

- Vervang `h264`-specifieke logica door een regex `codecTokenPattern` die tokens `h264|x264|avc|h265|x265|hevc|av1` (case-insensitief) matched en voeg `outputCodecTag(codec Codec)` toe om target-tag te bepalen (`HEVC`→`h265`, `AV1`→`av1`).
- Verander `BuildOutputPath` naar `BuildOutputPath(inputPath string, renameCodecTag bool, targetCodec Codec)` en update `FinalizeTranscode` naar `FinalizeTranscode(inputPath, tempPath string, replace bool, renameCodecTag bool, targetCodec Codec)` zodat de preset-codec gebruikt kan worden.
- Roep de nieuwe finalisatie-signature aan vanuit de worker met `preset.Codec` en gebruik de bestaande config-flag `RenameH264ToH265` als algemene toggle; update `internal/jobs/worker.go`, `internal/ffmpeg/transcode.go`, `internal/ffmpeg/transcode_test.go`, `internal/api/handler.go`, `internal/config/config.go`, `web/templates/index.html` en `README.md`.
- Voeg/werk unit tests bij voor `BuildOutputPath` (`TestBuildOutputPathRenameCodecTag` en `TestBuildOutputPathRenameCodecTagAV1`) en pas bestaande `FinalizeTranscode`-tests aan om de nieuwe parameterlijst te gebruiken.

### Testing

- Nieuwe en aangepaste unit tests zijn toegevoegd (`internal/ffmpeg/transcode_test.go` en `internal/api/handler_test.go`) but er is geen `go test` uitgevoerd in deze rollout.
- De code is geformatteerd met `gofmt` (`gofmt -w` uitgevoerd) en alle gewijzigde bestanden gecommit.
- UI wijziging in `web/templates/index.html` is bijgewerkt om de bredere functie te beschrijven, maar front-end tests of end-to-end checks zijn niet uitgevoerd.
- Playwright screenshot poging faalde in deze omgeving (bestand kon niet worden geopend), dus visuele verificatie is niet gelukt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960cdb9e1a883308e9cf4168600d341)